### PR TITLE
Only analyze the main source set with FindBugs/Checkstyle

### DIFF
--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -3,6 +3,7 @@ apply plugin: 'checkstyle'
 checkstyle {
     ignoreFailures = true
     configFile = new File(rootProject.projectDir, 'sun_checks.xml')
+    sourceSets = [sourceSets.main]
 }
 
 tasks.withType(Checkstyle) {
@@ -10,10 +11,4 @@ tasks.withType(Checkstyle) {
         xml.enabled = false
         html.enabled = true
     }
-}
-
-task checkstyle {
-    group = 'Verification'
-    description = 'Runs Checkstyle analysis for all classes.'
-    dependsOn tasks.withType(Checkstyle)
 }

--- a/gradle/findbugs.gradle
+++ b/gradle/findbugs.gradle
@@ -2,6 +2,7 @@ apply plugin: 'findbugs'
 
 findbugs {
     ignoreFailures = true
+    sourceSets = [sourceSets.main]
 }
 
 tasks.withType(FindBugs) {
@@ -9,10 +10,4 @@ tasks.withType(FindBugs) {
         xml.enabled = false
         html.enabled = true
     }
-}
-
-task findbugs {
-    group = 'Verification'
-    description = 'Runs FindBugs analysis for all classes.'
-    dependsOn tasks.withType(FindBugs)
 }


### PR DESCRIPTION
The provided solution tells FindBugs and Checkstyle to only analyze the `main` source set. Other source sets like `jmh` and `test` won't even hooked up to the `check` task. This is a far more elegant solution than having to remove tasks from the `check` task after the fact. For more information please see the extension of those plugins e.g. [CheckstyleExtension.sourceSets](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.CheckstyleExtension.html#org.gradle.api.plugins.quality.CheckstyleExtension:sourceSets).