### PR TITLE
refactor: 💡 change case order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ io/test.gz
 io/X.file
 *.pyc
 
+bin
 *.out
 *.err
 /files/bytes.dat

--- a/enumerations/Tanks.java
+++ b/enumerations/Tanks.java
@@ -23,12 +23,12 @@ record Tank(Type type, Level level) {}
 public class Tanks {
   static String check(Tank tank) {
     return switch(tank) {
-      case Tank t && t.type() == Type.TOXIC
-        -> "Toxic: " + t;
       case Tank t && (                 // [1]
           t.type() == Type.TOXIC &&
           t.level().percent() < 50
         ) -> "Toxic, low: " + t;
+      case Tank t && t.type() == Type.TOXIC
+              -> "Toxic: " + t;
       case Tank t && t.type() == Type.FLAMMABLE
         -> "Flammable: " + t;
       // Equivalent to "default":


### PR DESCRIPTION
Switch label 'Tank t && ( // [1] t.type() == Type.TOXIC && t.level().percent()...' is unreachable 